### PR TITLE
Fix: Persist dark mode preference and prevent flicker

### DIFF
--- a/app/components/DarkMode.tsx
+++ b/app/components/DarkMode.tsx
@@ -2,8 +2,17 @@
 import { MoonIcon, SunIcon } from "@heroicons/react/20/solid";
 import { useEffect, useState } from "react";
 
+const getInitialDarkMode = () => {
+	if (typeof window !== "undefined") {
+		const storedTheme = localStorage.getItem("theme");
+		return storedTheme === "dark";
+	}
+	return false; // Default to false if not on client-side
+};
+
 export default function DarkMode() {
-	const [darkMode, setDarkMode] = useState(false);
+	const [darkMode, setDarkMode] = useState(getInitialDarkMode());
+
 	useEffect(() => {
 		if (darkMode) {
 			document.documentElement.classList.add("dark");
@@ -13,15 +22,6 @@ export default function DarkMode() {
 			localStorage.setItem("theme", "light");
 		}
 	}, [darkMode]);
-
-	useEffect(() => {
-		const storedDarkMode = localStorage.getItem("theme");
-		if (storedDarkMode === "dark") {
-			setDarkMode(true);
-		} else {
-			setDarkMode(false);
-		}
-	}, []);
 
 	return (
 		<div>

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -24,6 +24,22 @@ export default function RootLayout({
 }>) {
 	return (
 		<html lang="en">
+			<script
+				dangerouslySetInnerHTML={{
+					__html: `
+            (function() {
+              try {
+                var theme = localStorage.getItem('theme');
+                if (theme === 'dark' || (!theme && window.matchMedia('(prefers-color-scheme: dark)').matches)) {
+                  document.documentElement.classList.add('dark');
+                } else {
+                  document.documentElement.classList.remove('dark');
+                }
+              } catch (_) {}
+            })();
+          `,
+				}}
+			/>
 			<meta
 				content="SjlrZnBfF0NOO11lm4GExHQRf9UM87k4de9teOQxKKc"
 				name="google-site-verification"


### PR DESCRIPTION
Your selected theme (dark or light) is now correctly persisted in localStorage and applied on subsequent page loads without flickering.

Changes made:
- Modified `app/components/DarkMode.tsx`:
    - Initialized `darkMode` state directly from `localStorage` on the client-side to prevent initial state mismatch.
    - Ensured this initialization is client-side only.
    - Removed a redundant `useEffect` hook that previously handled reading from `localStorage` after the initial render.
- Modified `app/layout.tsx`:
    - Added an inline script to the `<html>` tag. This script runs before page hydration to set the `dark` class on `document.documentElement` based on `localStorage` or system preference. This prevents a flash of incorrect theme.
- Verified `tailwind.config.ts`:
    - Ensured `darkMode` is set to `'class'`, which is necessary for the class-based dark mode to function correctly.

The combination of these changes ensures that the theme is applied immediately on page load based on the stored preference, providing a smoother user experience.